### PR TITLE
Fixes HttpClient thrashing, GetNotesSummary, cleanup

### DIFF
--- a/src/ApiException.cs
+++ b/src/ApiException.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Net;
+using IntakeQ.ApiClient.Models;
+using Newtonsoft.Json;
+
+namespace IntakeQ.ApiClient
+{
+    public class ApiException : Exception
+    {
+        public ApiError ApiError { get; }
+
+        public override string Message => ApiError?.Message ?? ResponseBody;
+
+        public string ResponseBody { get; }
+
+        public HttpStatusCode StatusCode { get; }
+
+        public ApiException(
+            HttpStatusCode statusCode,
+            string responseBody)
+        {
+            StatusCode = statusCode;
+            ResponseBody = responseBody;
+            ApiError = JsonConvert.DeserializeObject<ApiError>(responseBody);
+        }
+    }
+}

--- a/src/ClientBase.cs
+++ b/src/ClientBase.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using IntakeQ.ApiClient.Helpers;
+using IntakeQ.ApiClient.Models;
+using Newtonsoft.Json;
+
+
+namespace IntakeQ.ApiClient
+{
+    public abstract class ClientBase : IDisposable
+    {
+        private readonly string _apiKey;
+        protected readonly HttpClient _httpClient;
+
+        public ClientBase(string apiKey, string baseUrl)
+        {
+            _apiKey = apiKey;
+            _httpClient = new HttpClient()
+            {
+                BaseAddress = new Uri(baseUrl),
+            };
+            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _httpClient.DefaultRequestHeaders.Add("X-Auth-Key", _apiKey);
+#if DEBUG
+            ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => true;
+#endif
+        }
+
+        protected StringContent GetJsonContent(object jsonObject) => new StringContent(JsonConvert.SerializeObject(jsonObject), Encoding.UTF8, "application/json");
+
+        protected async Task<T> DeserializeResponse<T>(HttpResponseMessage response) => JsonConvert.DeserializeObject<T>(await response.Content.ReadAsStringAsync());
+
+        protected async Task PostOrThrow(string path, object jsonPayload = null)
+        {
+            var response = await _httpClient.PostAsync(path, jsonPayload == null ? null : GetJsonContent(jsonPayload));
+            await EnsureSuccess(response);
+        }
+
+        protected async Task<T> PostOrThrow<T>(string path, object jsonPayload = null)
+        {
+            var response = await _httpClient.PostAsync(path, jsonPayload == null ? null : GetJsonContent(jsonPayload));
+            await EnsureSuccess(response);
+            return await DeserializeResponse<T>(response);
+        }
+
+        protected async Task<T> PutOrThrow<T>(string path, object jsonPayload)
+        {
+            var response = await _httpClient.PutAsync(path, GetJsonContent(jsonPayload));
+            await EnsureSuccess(response);
+            return await DeserializeResponse<T>(response);
+        }
+
+        protected async Task DeleteOrThrow(string path)
+        {
+            var response = await _httpClient.DeleteAsync(path);
+            response.EnsureSuccessStatusCode();
+        }
+
+        protected async Task<T> GetOrThrow<T>(string path, (string Key, string Value)[] parameters = null)
+        {
+            var parameterCollection = new NameValueCollection();
+            parameters?
+                .Where(parameter => !string.IsNullOrEmpty(parameter.Value))
+                .ToList()
+                .ForEach(parameter => parameterCollection.Add(parameter.Key, parameter.Value));
+            var response = await _httpClient.GetAsync($"{path}{parameterCollection.ToQueryString()}");
+            await EnsureSuccess(response);
+            return await DeserializeResponse<T>(response);
+        }
+
+        protected async Task<byte[]> GetBytesOrThrow(string path)
+        {
+            var response = await _httpClient.GetAsync(path);
+            await EnsureSuccess(response);
+            return await response.Content.ReadAsByteArrayAsync();
+        }
+
+        protected async Task EnsureSuccess(HttpResponseMessage response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                throw new ApiException(response.StatusCode, responseBody);
+            }
+        }
+
+        public void Dispose()
+        {
+            _httpClient?.Dispose();
+        }
+    }
+}

--- a/src/Helpers/FromJavascripDateConverter.cs
+++ b/src/Helpers/FromJavascripDateConverter.cs
@@ -20,8 +20,8 @@ namespace IntakeQ.ApiClient.Helpers
         {
             var date = value as DateTime?;
             if (date == null) return;
-            
-            
+
+
             var epoch = date.Value.Subtract(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds;
             serializer.Serialize(writer, epoch.ToString("N0"));
         }

--- a/src/Models/ApiError.cs
+++ b/src/Models/ApiError.cs
@@ -1,0 +1,7 @@
+namespace IntakeQ.ApiClient.Models
+{
+    public class ApiError
+    {
+        public string Message { get; set; }
+    }
+}

--- a/src/Models/Appointment.cs
+++ b/src/Models/Appointment.cs
@@ -30,10 +30,10 @@ namespace IntakeQ.ApiClient.Models
         [JsonConverter(typeof(FromJavascripDateConverter))]
         public DateTime DateCreated { get; set; }
         public string CreatedBy { get; set; }
-        
+
         public bool BookedByClient { get; set; }
     }
-    
+
     public class CreateAppointmentDto
     {
         public int ClientId { get; set; }
@@ -47,7 +47,7 @@ namespace IntakeQ.ApiClient.Models
         public bool SendClientEmailNotification { get; set; }
         public string ReminderType { get; set; }
     }
-    
+
     public class UpdateAppointmentDto
     {
         public string Id { get; set; }

--- a/src/Models/ClientProfile.cs
+++ b/src/Models/ClientProfile.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace IntakeQ.ApiClient.Models
 {
-    public class ClientProfile 
+    public class ClientProfile
     {
         public int ClientId { get; set; }
         public string Name { get; set; }

--- a/src/Models/FormTemplate.cs
+++ b/src/Models/FormTemplate.cs
@@ -1,5 +1,5 @@
 namespace IntakeQ.ApiClient.Models
-{ 
+{
     /// <summary>
     /// Generic representation of a form template (Questionnaire, Treatment Note, Consent Form)
     /// </summary>

--- a/src/Models/Intake.cs
+++ b/src/Models/Intake.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace IntakeQ.ApiClient.Models
 {
-    public class Intake: IntakeSummary
+    public class Intake : IntakeSummary
     {
         public List<Question> Questions { get; set; }
         public List<ConsentForm> ConsentForms { get; set; }

--- a/src/Models/Invoice.cs
+++ b/src/Models/Invoice.cs
@@ -7,7 +7,7 @@ namespace IntakeQ.ApiClient.Models
 {
     public class Invoice
     {
-        
+
 
         public string Id { get; set; }
         public string Status { get; set; }
@@ -21,7 +21,7 @@ namespace IntakeQ.ApiClient.Models
         public decimal TotalAmount { get; set; }
         public decimal AmountDue { get; set; }
         public decimal AmountPaid { get; set; }
-        public List<string> AdditionalEmailRecipients { get; set; }             
+        public List<string> AdditionalEmailRecipients { get; set; }
         public List<InvoicePayment> Payments { get; set; }
         public string DiscountType { get; set; }
         public decimal DiscountPercent { get; set; }
@@ -31,32 +31,32 @@ namespace IntakeQ.ApiClient.Models
         public string Currency { get; set; }
         public bool AllowTipping { get; set; }
         public bool AllowPartialPayments { get; set; }
-      
+
         public string MemberId { get; set; }
 
         public bool Automated { get; set; }
         public string CreatedBy { get; set; }
-      
+
         public string CurrencyIso { get; set; }
-       
-        public List<string> DiagnosisList { get; set; }       
+
+        public List<string> DiagnosisList { get; set; }
 
         //Payment fields
         public decimal TipAmount { get; set; }
-       
+
         public List<InvoiceItem> Items { get; set; }
         public string ClientPaymentPlanId { get; set; }
         public int? ClientPaymentPlanInterval { get; set; }
         public int ClientIdNumber { get; set; }
-        
+
         public Invoice()
         {
             Items = new List<InvoiceItem>();
         }
     }
-    
-     public class InvoicePayment
-    {       
+
+    public class InvoicePayment
+    {
         public double Date { get; set; }
 
         /// <summary>
@@ -64,9 +64,9 @@ namespace IntakeQ.ApiClient.Models
         /// </summary>
         public decimal Amount { get; set; }
         public string Currency { get; set; }
-       
+
         public string Method { get; set; }
-        public string AdditionalInfo { get; set; }        
+        public string AdditionalInfo { get; set; }
         public decimal RefundedAmount { get; set; }
 
         /// <summary>
@@ -113,12 +113,12 @@ namespace IntakeQ.ApiClient.Models
         public decimal Price { get; set; }
         public decimal Units { get; set; }
         public string Description { get; set; }
-        
+
         public double? Date { get; set; }
 
         public List<string> Modifiers { get; set; }
     }
-    
+
     public class CardDetails
     {
         public string Brand { get; set; }

--- a/src/Models/Practitioner.cs
+++ b/src/Models/Practitioner.cs
@@ -12,7 +12,7 @@ namespace IntakeQ.ApiClient.Models
         public DateTime DateCreated { get; set; }
         public bool IsInactive { get; set; }
         public string RoleName { get; set; }
-        
+
         public string CompleteName => $"{FirstName} {LastName}";
     }
 }

--- a/src/Models/TreatmentNote.cs
+++ b/src/Models/TreatmentNote.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace IntakeQ.ApiClient.Models
 {
-    public class TreatmentNote: TreatmentNoteSummary
+    public class TreatmentNote : TreatmentNoteSummary
     {
         public List<Question> Questions { get; set; }
     }

--- a/src/PartnerApiClient.cs
+++ b/src/PartnerApiClient.cs
@@ -1,264 +1,63 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
 using System.Threading.Tasks;
-using IntakeQ.ApiClient.Helpers;
 using IntakeQ.ApiClient.Models;
-using Newtonsoft.Json;
-using System.IO;
-using Client = IntakeQ.ApiClient.Models.Client;
-using ClientProfile = IntakeQ.ApiClient.Models.ClientProfile;
 
 
 namespace IntakeQ.ApiClient
 {
-    public class PartnerApiClient
+    public class PartnerApiClient : ClientBase
     {
-        private readonly string _apiKey;
-        private readonly string _baseUrl = "https://intakeq.com/api/partner/";
-        public PartnerApiClient(string apiKey)
+        private static readonly string _baseUrl = "https://intakeq.com/api/partner/";
+
+        public PartnerApiClient(string apiKey) : base(apiKey, _baseUrl)
         {
-            _apiKey = apiKey;
-#if DEBUG
-            ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => true;
-#endif
         }
 
-        private HttpRequestMessage GetHttpMessage(string methodName, HttpMethod methodType)
-        {
-            var request = new HttpRequestMessage()
+        public async Task<IEnumerable<Practice>> GetPractices(int? pageNumber = null) => await GetOrThrow<IEnumerable<Practice>>(
+            "practice",
+            new[]
             {
-                RequestUri = new Uri(_baseUrl + methodName),
-                Method = methodType,
-            };
-            request.Headers.Add("X-Auth-Key", _apiKey);
-            return request;
-        }
-        
-        public async Task<IEnumerable<Practice>> GetPractices(int? pageNumber = null)
-        {
-            using (HttpClient client = new HttpClient())
+                ("page", pageNumber.HasValue ? pageNumber.Value.ToString() : null)
+            });
+
+        public async Task<Practice> GetPracticeById(string id) =>
+            (await GetOrThrow<List<Practice>>(
+                "practice",
+                new[]
+                {
+                    ("id", id)
+                })
+            )
+            .FirstOrDefault();
+
+        public async Task<Practice> GetPracticeByExternalId(string externalPracticeId) =>
+            (await GetOrThrow<List<Practice>>(
+                "practice",
+                new[]
+                {
+                    ("externalPracticeId", externalPracticeId)
+                })
+            )
+            .FirstOrDefault();
+
+        public async Task<Practice> CreatePractice(Practice practice) => await PostOrThrow<Practice>("practice", practice);
+
+        public async Task<Practice> UpdatePractice(Practice practice) => await PutOrThrow<Practice>("practice", practice);
+
+        public async Task<string> GetPracticeApiKey(string idOrExternalPracticeId) => (await GetOrThrow<dynamic>($"practice/{idOrExternalPracticeId}/key"))?.ApiKey;
+
+        public async Task<EphemeralToken> GetEphemeralToken(string idOrExternalPracticeId, string userId = null) => await GetOrThrow<EphemeralToken>(
+            $"practice/{idOrExternalPracticeId}/ephemeral",
+            new[]
             {
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                ("userId", userId)
+            });
 
-                var parameters = new NameValueCollection();
-                if (pageNumber.HasValue)
-                    parameters.Add("page", pageNumber.Value.ToString());
+        public async Task<List<FormTemplate>> ListMasterForms() => await GetOrThrow<List<FormTemplate>>("masterForms");
 
-                var request = GetHttpMessage("practice" + parameters.ToQueryString(), HttpMethod.Get);
-                HttpResponseMessage response = await client.SendAsync(request);
-                if (response.IsSuccessStatusCode)
-                {
-                    var json = await response.Content.ReadAsStringAsync();
-                    var practices = JsonConvert.DeserializeObject<IEnumerable<Practice>>(json);
-                    return practices;
-                }
-                else
-                {
-                    throw new HttpRequestException(await response.Content.ReadAsStringAsync());
-                }
-            }
-        }
-        
-        public async Task<Practice> GetPracticeById(string id)
-        {
-            using (HttpClient client = new HttpClient())
-            {
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        public async Task<List<FormTemplate>> ListPracticeForms(string practiceId) => await GetOrThrow<List<FormTemplate>>($"practice/{practiceId}/forms");
 
-                var parameters = new NameValueCollection();
-                parameters.Add("id", id);
-
-                var request = GetHttpMessage("practice" + parameters.ToQueryString(), HttpMethod.Get);
-                HttpResponseMessage response = await client.SendAsync(request);
-                if (response.IsSuccessStatusCode)
-                {
-                    var json = await response.Content.ReadAsStringAsync();
-                    var practices = JsonConvert.DeserializeObject<List<Practice>>(json);
-                    return practices.FirstOrDefault();
-                }
-                else
-                {
-                    throw new HttpRequestException(await response.Content.ReadAsStringAsync());
-                }
-            }
-        }
-        
-        public async Task<Practice> GetPracticeByExternalId(string externalPracticeId)
-        {
-            using (HttpClient client = new HttpClient())
-            {
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-
-                var parameters = new NameValueCollection();
-                parameters.Add("externalPracticeId", externalPracticeId);
-
-                var request = GetHttpMessage("practice" + parameters.ToQueryString(), HttpMethod.Get);
-                HttpResponseMessage response = await client.SendAsync(request);
-                if (response.IsSuccessStatusCode)
-                {
-                    var json = await response.Content.ReadAsStringAsync();
-                    var practices = JsonConvert.DeserializeObject<List<Practice>>(json);
-                    return practices.FirstOrDefault();
-                }
-                else
-                {
-                    throw new HttpRequestException(await response.Content.ReadAsStringAsync());
-                }
-            }
-        }
-   
-        public async Task<Practice> CreatePractice(Practice practice)
-        {
-            using (HttpClient client = new HttpClient())
-            {
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-
-               var request = GetHttpMessage($"practice", HttpMethod.Post);
-                request.Content = new StringContent(JsonConvert.SerializeObject(practice), Encoding.UTF8, "application/json");
-
-                HttpResponseMessage response = await client.SendAsync(request);
-                if (response.IsSuccessStatusCode)
-                {
-                    var json = await response.Content.ReadAsStringAsync();
-                    return JsonConvert.DeserializeObject<Practice>(json);
-                }
-                else
-                {
-                    throw new HttpRequestException(await response.Content.ReadAsStringAsync());
-                }
-            }
-        }
-        
-        public async Task<Practice> UpdatePractice(Practice practice)
-        {
-            using (HttpClient client = new HttpClient())
-            {
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-
-                var request = GetHttpMessage($"practice", HttpMethod.Put);
-                request.Content = new StringContent(JsonConvert.SerializeObject(practice), Encoding.UTF8, "application/json");
-
-                HttpResponseMessage response = await client.SendAsync(request);
-                if (response.IsSuccessStatusCode)
-                {
-                    var json = await response.Content.ReadAsStringAsync();
-                    return JsonConvert.DeserializeObject<Practice>(json);
-                }
-                else
-                {
-                    throw new HttpRequestException(await response.Content.ReadAsStringAsync());
-                }
-            }
-        }
-
-        public async Task<string> GetPracticeApiKey(string idOrExternalPracticeId)
-        {
-            using (HttpClient client = new HttpClient())
-            {
-                var request = GetHttpMessage($"practice/{idOrExternalPracticeId}/key", HttpMethod.Get);
-
-                 HttpResponseMessage response = await client.SendAsync(request);
-                if (response.IsSuccessStatusCode)
-                {   
-                    var json = await response.Content.ReadAsStringAsync();
-                    dynamic result = JsonConvert.DeserializeObject(json);
-                    return result?.ApiKey;
-                }
-                else
-                {
-                    throw new HttpRequestException(await response.Content.ReadAsStringAsync());
-                }
-            }
-        }
-        
-        public async Task<EphemeralToken> GetEphemeralToken(string idOrExternalPracticeId, string userId = null)
-        {
-            using (HttpClient client = new HttpClient())
-            {
-                var parameters = new NameValueCollection();
-                if (!string.IsNullOrEmpty(userId))
-                    parameters.Add("userId", userId);
-                
-                var request = GetHttpMessage($"practice/{idOrExternalPracticeId}/ephemeral" + parameters.ToQueryString(), HttpMethod.Get);
-                
-                HttpResponseMessage response = await client.SendAsync(request);
-                if (response.IsSuccessStatusCode)
-                {   
-                    var json = await response.Content.ReadAsStringAsync();
-                    var result = JsonConvert.DeserializeObject<EphemeralToken>(json);
-                    return result;
-                }
-                else
-                {
-                    throw new HttpRequestException(await response.Content.ReadAsStringAsync());
-                }
-            }
-        }
-        
-        public async Task<List<FormTemplate>> ListMasterForms()
-        {
-            using (HttpClient client = new HttpClient())
-            {
-                var request = GetHttpMessage($"masterForms", HttpMethod.Get);
-
-                HttpResponseMessage response = await client.SendAsync(request);
-                if (response.IsSuccessStatusCode)
-                {   
-                    var json = await response.Content.ReadAsStringAsync();
-                    return JsonConvert.DeserializeObject<List<FormTemplate>>(json);
-                }
-                else
-                {
-                    throw new HttpRequestException(await response.Content.ReadAsStringAsync());
-                }
-            }
-        }
-        
-        public async Task<List<FormTemplate>> ListPracticeForms(string practiceId)
-        {
-            using (HttpClient client = new HttpClient())
-            {
-                var request = GetHttpMessage($"practice/{practiceId}/forms", HttpMethod.Get);
-
-                HttpResponseMessage response = await client.SendAsync(request);
-                if (response.IsSuccessStatusCode)
-                {   
-                    var json = await response.Content.ReadAsStringAsync();
-                    return JsonConvert.DeserializeObject<List<FormTemplate>>(json);
-                }
-                else
-                {
-                    throw new HttpRequestException(await response.Content.ReadAsStringAsync());
-                }
-            }
-        }
-        
-        public async Task<FormTemplate> CopyForm(CopyFormOptions options)
-        {
-            using (HttpClient client = new HttpClient())
-            {
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-
-                var request = GetHttpMessage("practice/copyForm", HttpMethod.Post);
-                request.Content = new StringContent(JsonConvert.SerializeObject(options), Encoding.UTF8, "application/json");
-
-                HttpResponseMessage response = await client.SendAsync(request);
-                if (response.IsSuccessStatusCode)
-                {
-                    var json = await response.Content.ReadAsStringAsync();
-                    return JsonConvert.DeserializeObject<FormTemplate>(json);
-                }
-                else
-                {
-                    throw new HttpRequestException(await response.Content.ReadAsStringAsync());
-                }
-            }
-        }
+        public async Task<FormTemplate> CopyForm(CopyFormOptions options) => await PostOrThrow<FormTemplate>("practice/copyForm", options);
     }
 }


### PR DESCRIPTION
  - `GetNotesSummary` was not using the right status flag
  - Remove a bunch of copy/pasted code
  - `HttpClient` would be created/disposed often which can cause a lot of open sockets to hang around during high volumes of API traffic
  - Moving to `ApiException` instead of `HttpRequestException`
    - Old implementations of `HttpRequestException` don't expose useful things like status codes, so 401s just present an empty message (this is somewhat fixed in .NET Core but still clunky, but we still support .NET 4.8 so that's not an option).
    - The API _does_ seem to return valid JSON error messages for 400s and the like, we should support those appropriately
 
---

Currently keeping this PR open as a draft, going to do a lot of testing/verification of this and possibly further discussions on our side on if there is anything I've generally missed before poking IntakeQ much on this.

## THIS IS A BACKWARDS COMPATIBLE BREAKING CHANGE

This will likely push us to a v2.0 on the lib, however there is a pretty sizeable performance barrier created by not allowing us to reuse `HttpClient` if we're making a lot of API calls, see: https://www.aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/

The main goal of this change is to tie the lifetime of the `HttpClient` instance to the lifespan of the API service client, this allows for a lot of efficiency gains (CPU usage, memory usage, prevent socket exhaustion).

As part of these changes I figured removing duplicate code would be ideal since I had to basically touch everything anyway to update it.

### This is not a high priority set of fixes for us

Mainly kicking this out so we have a record since it's come up on our end a few times, and opening this for wider discussion.

We've run our test suite that is doing operations against IntakeQ against these updates and the tests are still passing, but still going to review this more.